### PR TITLE
PIV Idents Missing on Cert Error, Pub keys fail to parse

### DIFF
--- a/.github/workflows/config_check.yml
+++ b/.github/workflows/config_check.yml
@@ -2,9 +2,9 @@ name: Check Configuration Examples
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,9 +2,9 @@ name: Integration Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Feature Compilation Check
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/rustica-agent/src/config/multimode.rs
+++ b/rustica-agent/src/config/multimode.rs
@@ -41,7 +41,7 @@ fn get_keys_from_dir(directory: &str) -> Result<(Vec<PublicKey>, Vec<PrivateKey>
         };
 
         // If it's a .pub, try to parse it as a public key
-        if key_path.ends_with(".pub") {
+        if key_path.display().to_string().ends_with(".pub") {
             match PublicKey::from_path(&key_path) {
                 Ok(key) => public_keys.push(key),
                 Err(e) => println!("Error for {}: {e}", key_path.to_string_lossy()),
@@ -54,6 +54,12 @@ fn get_keys_from_dir(directory: &str) -> Result<(Vec<PublicKey>, Vec<PrivateKey>
             }
         }
     }
+
+    println!(
+        "Loaded: {} public keys, and {} private keys",
+        public_keys.len(),
+        private_keys.len()
+    );
 
     return Ok((public_keys, private_keys));
 }

--- a/rustica-agent/src/lib.rs
+++ b/rustica-agent/src/lib.rs
@@ -275,6 +275,7 @@ impl SshAgentHandler for Handler {
                     key_blob: self.pubkey.encode().to_vec(),
                     key_comment: format!("Only key available, Certificate refresh error: {e}, "),
                 });
+                identities.append(&mut extra_identities);
             }
         }
         return Ok(Response::Identities(identities));


### PR DESCRIPTION
Fixes a couple bugs in multi mode and with PIV identities where they wouldn't be presented in the case the server refused to issue a certificate.