### PR TITLE
New Dockerfile for minimal container focusing on homelab use

### DIFF
--- a/docker/Dockerfile_homelab
+++ b/docker/Dockerfile_homelab
@@ -1,0 +1,23 @@
+FROM rust:1.65 as builder
+
+RUN apt update
+RUN apt install -y pkg-config libpcsclite-dev
+#RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+
+RUN rustup component add rustfmt
+RUN mkdir /rustica
+COPY proto /tmp/proto
+COPY rustica /tmp/rustica
+WORKDIR /tmp/rustica
+
+RUN cargo build --features="yubikey-support,webhook,amazon-kms,influx,local-db" --release
+
+
+FROM ubuntu:20.04
+RUN apt update
+RUN apt install -y libpcsclite-dev 
+
+COPY --from=builder /tmp/rustica/target/release/rustica /rustica
+USER 1000
+ENTRYPOINT [ "/rustica" ]
+


### PR DESCRIPTION
Add a new Dockerfile generally targeted at home use. Compile in all features and use the minimal Ubuntu container.

I tried to use Alpine but could not make it work when Yubikey support was compiled in, I think because `hidapi` library links libc in some way that is not working with MUSL and the resulting binary always relies on the gnulibc.

Further, both gcompat and libc6-compat failed to work causing panics in the standard library during a thread operation.

- [x] TODO: Add localdb which was forgotten