### PR TITLE
Rustica Agent Multi Mode/Additional Keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3269,6 +3269,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.12.3",
  "eframe",
+ "hex",
  "home",
  "rustica-agent",
  "sshcerts 0.12.0",

--- a/rustica-agent-cli/src/main.rs
+++ b/rustica-agent-cli/src/main.rs
@@ -51,6 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 &config.subject,
                 &config.management_key,
                 config.require_touch,
+                config.pin_policy,
             ) {
                 Some(_) => (),
                 None => {

--- a/rustica-agent-gui/Cargo.toml
+++ b/rustica-agent-gui/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 base64 = "0.12"
 eframe = "0.19.0"
+hex = "0.4"
 home = "0.5"
 rustica-agent = {path = "../rustica-agent"}
 sshcerts = {git = "https://github.com/obelisk/sshcerts", branch = "bug_fixes_2022_07_06", features = ["yubikey-support", "fido-support"]}

--- a/rustica-agent-gui/src/main.rs
+++ b/rustica-agent-gui/src/main.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::{HashMap, HashSet}, path::PathBuf};
 
-use eframe::egui::{self, Grid, Sense /*Sense*/};
+use eframe::egui::{self, Grid, Sense, TextEdit /*Sense*/};
 
 use egui::ComboBox;
 
@@ -53,6 +53,7 @@ struct RusticaAgentGui {
     fido_devices: Vec<FidoDeviceDescriptor>,
     selected_fido_device: Option<usize>,
     piv_keys: HashMap<Vec<u8>, YubikeyPIVKeyDescriptorWithUse>,
+    unlock_pin: String,
 }
 
 fn check_create_dir<'a, T>(path: T) -> Result<Vec<PathBuf>, RusticaAgentGuiError>
@@ -124,6 +125,7 @@ fn load_environments() -> Result<RusticaAgentGui, RusticaAgentGuiError> {
         fido_devices,
         selected_fido_device,
         piv_keys,
+        unlock_pin: String::new(),
     })
 }
 
@@ -226,7 +228,12 @@ impl eframe::App for RusticaAgentGui {
                     ui.add(egui::Separator::default());
                     ui.vertical_centered(|ui| {
                         ui.label("Additional Keys");
-                        Grid::new("my_grid")
+                        ui.horizontal(|ui| {
+                            ui.label("Unlock Pin");
+                            ui.add(TextEdit::singleline(&mut self.unlock_pin).password(true));
+                        });
+                        
+                        Grid::new("additional_keys_list")
                             .num_columns(5)
                             .spacing([40.0, 4.0])
                             .striped(true)

--- a/rustica-agent-gui/src/main.rs
+++ b/rustica-agent-gui/src/main.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-use std::{collections::{HashMap, HashSet}, path::PathBuf, hash::Hash};
+use std::{collections::HashMap, path::PathBuf};
 
 use eframe::egui::{self, Grid, Sense, TextEdit, Button /*Sense*/};
 

--- a/rustica-agent/src/ffi.rs
+++ b/rustica-agent/src/ffi.rs
@@ -579,6 +579,8 @@ pub unsafe extern "C" fn start_direct_rustica_agent_with_piv_idents(
             Err(_) => return std::ptr::null(),
         };
 
+        let subject = yk.fetch_subject(&slot).unwrap_or_default();
+
         piv_identities.insert(
             pubkey.encode().to_vec(),
             YubikeyPIVKeyDescriptor {
@@ -586,6 +588,7 @@ pub unsafe extern "C" fn start_direct_rustica_agent_with_piv_idents(
                 serial,
                 slot,
                 pin,
+                subject,
             },
         );
     }

--- a/rustica-agent/src/lib.rs
+++ b/rustica-agent/src/lib.rs
@@ -432,6 +432,7 @@ pub fn provision_new_key(
     subj: &str,
     mgm_key: &[u8],
     require_touch: bool,
+    pin_policy: PinPolicy,
 ) -> Option<PIVAttestation> {
     println!("Provisioning new NISTP384 key in slot: {:?}", &yubikey.slot);
 
@@ -452,7 +453,7 @@ pub fn provision_new_key(
         subj,
         AlgorithmId::EccP384,
         policy,
-        PinPolicy::Never,
+        pin_policy,
     ) {
         Ok(_) => {
             let certificate = yubikey.yk.fetch_attestation(&yubikey.slot);

--- a/rustica-agent/src/lib.rs
+++ b/rustica-agent/src/lib.rs
@@ -82,6 +82,7 @@ pub struct YubikeyPIVKeyDescriptor {
     pub slot: SlotId,
     pub public_key: PublicKey,
     pub pin: Option<String>,
+    pub subject: String,
 }
 
 #[derive(Debug)]
@@ -527,11 +528,13 @@ pub fn get_all_piv_keys(
                 for slot in 0x82..0x96_u8 {
                     let slot = SlotId::Retired(RetiredSlotId::try_from(slot).unwrap());
                     if let Ok(pubkey) = yk.ssh_cert_fetch_pubkey(&slot) {
+                        let subject = yk.fetch_subject(&slot).unwrap_or_default();
                         let descriptor = YubikeyPIVKeyDescriptor {
                             serial,
                             slot,
                             public_key: pubkey.clone(),
                             pin: pin.clone(),
+                            subject,
                         };
                         all_keys.insert(pubkey.encode().to_vec(), descriptor);
                     }

--- a/rustica-agent/src/lib.rs
+++ b/rustica-agent/src/lib.rs
@@ -76,7 +76,7 @@ pub enum Signatory {
     Direct(PrivateKey),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct YubikeyPIVKeyDescriptor {
     pub serial: u32,
     pub slot: SlotId,


### PR DESCRIPTION
This adds support for multi mode or additional keys as it's called in the UI.

This scans all connected PIV Yubikeys to enumerate all the keys and presents them in a list.

To use a key it must be unlocked and checked. When you click start to start or restart RusticaAgent, it will present that key along with the others (after the primary key and its certificate).

This allows you to use them for connecting to hosts, codesigning, or other features that use a connected SSH agent which you would like to bring resident keys to.