### PR TITLE
Add more security checks for challenge

### DIFF
--- a/rustica-agent/src/rustica/error.rs
+++ b/rustica-agent/src/rustica/error.rs
@@ -11,6 +11,7 @@ pub struct ServerError {
 pub enum RefreshError {
     TransportError,
     SigningError,
+    ServerChallengeNotForClientKey,
     UnsupportedMode,
     InvalidUri,
     ConfigurationError(String),
@@ -25,6 +26,7 @@ impl fmt::Display for RefreshError {
         match *self {
             RefreshError::ConfigurationError(ref err) => write!(f, "Configuration is invalid: {}", err),
             RefreshError::TransportError => write!(f, "Transport Error. Generally a TLS issue"),
+            RefreshError::ServerChallengeNotForClientKey => write!(f, "Server challenge is not for your key"),
             RefreshError::SigningError => write!(f, "Signing or verification failed"),
             RefreshError::UnsupportedMode => write!(f, "Attempted to use a curve or cipher not supported by rustica-agent"),
             RefreshError::InvalidUri => write!(f, "Provided address of remote service was invalid"),

--- a/rustica/src/server.rs
+++ b/rustica/src/server.rs
@@ -209,7 +209,7 @@ fn validate_request(
     })?;
 
     let hmac_challenge = &parsed_certificate.key_id;
-    let hmac_verification = format!("{}-{}", request_time, challenge.pubkey);
+    let hmac_verification = format!("{}-{}-{}", request_time, challenge.pubkey, cert_info.identities.join(","));
     let decoded_challenge =
         hex::decode(&hmac_challenge).map_err(|_| RusticaServerError::BadChallenge)?;
 
@@ -364,7 +364,7 @@ impl Rustica for RusticaServer {
             .as_secs()
             .to_string();
         let pubkey = &request.pubkey;
-        let challenge = format!("{}-{}", timestamp, pubkey);
+        let challenge = format!("{}-{}-{}", timestamp, pubkey, mtls_identities.join(","));
         let tag = hmac::sign(&self.hmac_key, challenge.as_bytes());
 
         // Build an SSHCertificate as a challenge


### PR DESCRIPTION
This PR includes two changes:

### 1. Binding challenge to mTLS identity

This prevents a challenge issued to a user from being used for another user.

### 2. Check the challenge pubkey on the client

Ensure that the client doesn't sign an SSH certificate for an unknown SSH pubkey.

#### Manual tests done:
- Modified server code to modify the pubkey in the challenge
- Set `require_rustica_proof=true`
- Rebuilt and launched the local Rustica server
- Rebuilt and ran the Rustica Client CLI in `immediate` mode against the local Rustica server. Got the expected failure:
```
[2023-11-09T20:25:59Z DEBUG rustica_agent::rustica] The public key in the challenge doesn't match the client's public key
[2023-11-09T20:25:59Z ERROR rustica_agent] Could not fetch certificate from: https://localhost:50052. Gave error: Signing or verification failed
[2023-11-09T20:25:59Z DEBUG h2::codec::framed_write] send frame=GoAway { error_code: NO_ERROR, last_stream_id: StreamId(0) }
[2023-11-09T20:25:59Z DEBUG h2::proto::connection] Connection::poll; connection error error=GoAway(b"", NO_ERROR, Library)
[2023-11-09T20:25:59Z DEBUG rustls::common_state] Sending warning alert CloseNotify
```