### PR TITLE
Implement multithread

### DIFF
--- a/rustica-agent-cli/src/config/mod.rs
+++ b/rustica-agent-cli/src/config/mod.rs
@@ -53,7 +53,7 @@ pub enum RusticaAgentAction {
     ListPIVKeys(listpivkeys::ListPIVKeysConfig),
     ListFidoDevices,
     GitConfig(PublicKey),
-    RefreshAttestedX509(refresh_attested_x509_certificate::RefreshAttestedX509Config)
+    RefreshAttestedX509(refresh_attested_x509_certificate::RefreshAttestedX509Config),
 }
 
 impl From<std::io::Error> for ConfigurationError {
@@ -85,7 +85,7 @@ fn get_signatory(
     match (cmd_slot, config_slot, file, &config_key) {
         (Some(slot), _, _, _) => match slot_parser(slot) {
             Some(s) => Ok(Signatory::Yubikey(YubikeySigner {
-                yk: Yubikey::new().unwrap(),
+                yk: Yubikey::new().unwrap().into(),
                 slot: s,
             })),
             None => Err(ConfigurationError::BadSlot),
@@ -99,7 +99,7 @@ fn get_signatory(
         },
         (_, Some(slot), _, _) => match slot_parser(slot) {
             Some(s) => Ok(Signatory::Yubikey(YubikeySigner {
-                yk: Yubikey::new().unwrap(),
+                yk: Yubikey::new().unwrap().into(),
                 slot: s,
             })),
             None => Err(ConfigurationError::BadSlot),
@@ -166,7 +166,9 @@ pub fn add_daemon_options(cmd: Command) -> Command {
         )
 }
 
-fn parse_config_from_args(matches: &ArgMatches) -> Result<UpdatableConfiguration, ConfigurationError> {
+fn parse_config_from_args(
+    matches: &ArgMatches,
+) -> Result<UpdatableConfiguration, ConfigurationError> {
     UpdatableConfiguration::new(matches.value_of("config").unwrap())
         .map_err(|e| ConfigurationError::BadConfiguration(e))
 }
@@ -255,10 +257,11 @@ pub async fn configure() -> Result<RusticaAgentAction, ConfigurationError> {
             .about("Show the git configuration for code-signing with the provided key"),
     );
 
-    let refresh_x509 = refresh_attested_x509_certificate::add_configuration(new_run_agent_subcommand(
-        "refresh-attested-x509",
-        "Refresh an X509 certificate in a Yubikey slot",
-    ));
+    let refresh_x509 =
+        refresh_attested_x509_certificate::add_configuration(new_run_agent_subcommand(
+            "refresh-attested-x509",
+            "Refresh an X509 certificate in a Yubikey slot",
+        ));
 
     let command_configuration = command_configuration
         .subcommand(immediate_mode)
@@ -312,7 +315,8 @@ pub async fn configure() -> Result<RusticaAgentAction, ConfigurationError> {
     }
 
     if let Some(x509_config) = matches.subcommand_matches("refresh-x509") {
-        return refresh_attested_x509_certificate::configure_refresh_x509_certificate(x509_config).await;
+        return refresh_attested_x509_certificate::configure_refresh_x509_certificate(x509_config)
+            .await;
     }
 
     cc_help.print_help().unwrap();

--- a/rustica-agent-cli/src/config/mod.rs
+++ b/rustica-agent-cli/src/config/mod.rs
@@ -91,7 +91,7 @@ fn get_signatory(
             None => Err(ConfigurationError::BadSlot),
         },
         (_, _, Some(file), _) => match PrivateKey::from_path(file) {
-            Ok(p) => Ok(Signatory::Direct(p)),
+            Ok(p) => Ok(Signatory::Direct(p.into())),
             Err(e) => Err(ConfigurationError::CannotReadFile(format!(
                 "{}: {}",
                 e, file
@@ -104,7 +104,7 @@ fn get_signatory(
             })),
             None => Err(ConfigurationError::BadSlot),
         },
-        (_, _, _, Some(key_string)) => Ok(Signatory::Direct(PrivateKey::from_string(key_string)?)),
+        (_, _, _, Some(key_string)) => Ok(Signatory::Direct(PrivateKey::from_string(key_string)?.into())),
         (None, None, None, None) => Err(ConfigurationError::MissingSSHKey),
     }
 }

--- a/rustica-agent-cli/src/config/multimode.rs
+++ b/rustica-agent-cli/src/config/multimode.rs
@@ -102,7 +102,7 @@ fn get_signatory(
         if certificate_fingerprint == private_key.pubkey.fingerprint().hash {
             return Ok((
                 private_key.pubkey.clone(),
-                Signatory::Direct(private_key.clone()),
+                Signatory::Direct(private_key.clone().into()),
             ));
         }
     }

--- a/rustica-agent-cli/src/config/multimode.rs
+++ b/rustica-agent-cli/src/config/multimode.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, fs};
 
 use rustica_agent::{
     get_all_piv_keys, Handler, RusticaAgentLibraryError, Signatory, YubikeyPIVKeyDescriptor,
-    YubikeySigner
+    YubikeySigner,
 };
 
 use clap::{Arg, ArgMatches, Command};
@@ -91,7 +91,7 @@ fn get_signatory(
         let key = PublicKey::from_bytes(key).unwrap();
         if certificate_fingerprint == key.fingerprint().hash {
             let sig = Signatory::Yubikey(YubikeySigner {
-                yk: Yubikey::open(des.serial).unwrap(),
+                yk: Yubikey::open(des.serial).unwrap().into(),
                 slot: des.slot,
             });
             return Ok((des.public_key.clone(), sig));
@@ -157,17 +157,16 @@ pub async fn configure_multimode(
     key_map.remove(&pubkey.encode().to_vec());
 
     let handler = Handler {
-        updatable_configuration,
-        cert: None,
+        updatable_configuration: updatable_configuration.into(),
+        cert: None.into(),
         pubkey: pubkey.clone(),
         signatory,
-        stale_at: 0,
+        stale_at: 0.into(),
         certificate_options,
-        identities: private_keys,
+        identities: private_keys.into(),
         piv_identities: key_map,
         notification_function: None,
         certificate_priority: matches.is_present("certificate-priority"),
-        
     };
 
     Ok(RusticaAgentAction::Run(RunConfig {

--- a/rustica-agent-cli/src/config/refresh_attested_x509_certificate.rs
+++ b/rustica-agent-cli/src/config/refresh_attested_x509_certificate.rs
@@ -1,10 +1,12 @@
 use std::env;
 
-use clap::{Command, Arg, ArgMatches};
-use rustica_agent::{slot_validator, slot_parser, Signatory, YubikeySigner, config::UpdatableConfiguration};
+use clap::{Arg, ArgMatches, Command};
+use rustica_agent::{
+    config::UpdatableConfiguration, slot_parser, slot_validator, Signatory, YubikeySigner,
+};
 use sshcerts::yubikey::piv::Yubikey;
 
-use super::{RusticaAgentAction, ConfigurationError, parse_config_from_args};
+use super::{parse_config_from_args, ConfigurationError, RusticaAgentAction};
 
 pub struct RefreshAttestedX509Config {
     pub updatable_configuration: UpdatableConfiguration,
@@ -22,7 +24,7 @@ pub async fn configure_refresh_x509_certificate(
     let slot = slot_parser(&slot).unwrap();
 
     let signatory = Signatory::Yubikey(YubikeySigner {
-        yk: Yubikey::new().unwrap(),
+        yk: Yubikey::new().unwrap().into(),
         slot,
     });
 
@@ -37,42 +39,42 @@ pub async fn configure_refresh_x509_certificate(
         Err(_) => return Err(ConfigurationError::YubikeyManagementKeyInvalid),
     };
 
-
-    Ok(RusticaAgentAction::RefreshAttestedX509(RefreshAttestedX509Config {
-        updatable_configuration,
-        signatory,
-        pin,
-        management_key,
-    }))
+    Ok(RusticaAgentAction::RefreshAttestedX509(
+        RefreshAttestedX509Config {
+            updatable_configuration,
+            signatory,
+            pin,
+            management_key,
+        },
+    ))
 }
 
 pub fn add_configuration(cmd: Command) -> Command {
-    cmd
-        .arg(
-            Arg::new("slot")
-                .help("Numerical value for the slot on the yubikey to use for your private key")
-                .long("slot")
-                .short('s')
-                .required(true)
-                .validator(slot_validator)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::new("pin-env")
-                .help("Specify a different pin environment variable")
-                .default_value("YK_PIN")
-                .long("pinenv")
-                .short('p')
-                .required(false)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::new("management-key")
-                .help("Specify the management key")
-                .default_value("010203040506070801020304050607080102030405060708")
-                .long("mgmkey")
-                .short('m')
-                .required(false)
-                .takes_value(true),
-        )
+    cmd.arg(
+        Arg::new("slot")
+            .help("Numerical value for the slot on the yubikey to use for your private key")
+            .long("slot")
+            .short('s')
+            .required(true)
+            .validator(slot_validator)
+            .takes_value(true),
+    )
+    .arg(
+        Arg::new("pin-env")
+            .help("Specify a different pin environment variable")
+            .default_value("YK_PIN")
+            .long("pinenv")
+            .short('p')
+            .required(false)
+            .takes_value(true),
+    )
+    .arg(
+        Arg::new("management-key")
+            .help("Specify the management key")
+            .default_value("010203040506070801020304050607080102030405060708")
+            .long("mgmkey")
+            .short('m')
+            .required(false)
+            .takes_value(true),
+    )
 }

--- a/rustica-agent-cli/src/config/singlemode.rs
+++ b/rustica-agent-cli/src/config/singlemode.rs
@@ -29,6 +29,7 @@ pub async fn configure_singlemode(
             }
         }
         Signatory::Direct(privkey) => {
+            let mut privkey = privkey.lock().await;
             if let Some(path) = matches.value_of("fido-device-path") {
                 privkey.set_device_path(path);
             }

--- a/rustica-agent-cli/src/main.rs
+++ b/rustica-agent-cli/src/main.rs
@@ -67,7 +67,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(RusticaAgentAction::ProvisionAndRegisterFido(prf)) => {
             let new_fido_key = generate_new_ssh_key(&prf.app_name, &prf.comment, prf.pin, None)?;
 
-            let mut signatory = Signatory::Direct(new_fido_key.private_key.clone());
+            let mut signatory = Signatory::Direct(new_fido_key.private_key.clone().into());
             let u2f_attestation = U2FAttestation {
                 auth_data: new_fido_key.attestation.auth_data,
                 auth_data_sig: new_fido_key.attestation.auth_data_sig,

--- a/rustica-agent-gui/src/main.rs
+++ b/rustica-agent-gui/src/main.rs
@@ -137,7 +137,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let agent = load_environments()?; //.into_iter().map(|x| x.to_string_lossy().to_string()).collect();
 
     let options = eframe::NativeOptions::default();
-    eframe::run_native(
+    let _ = eframe::run_native(
         "Rustica Agent",
         options,
         Box::new(move |_cc| Box::new(agent)),
@@ -304,13 +304,13 @@ impl eframe::App for RusticaAgentGui {
                                         let certificate_options = CertificateConfig::from(updatable_configuration.get_configuration().options.clone());
 
                                         let handler = rustica_agent::Handler {
-                                            updatable_configuration,
-                                            cert: None,
+                                            updatable_configuration: updatable_configuration.into(),
+                                            cert: None.into(),
                                             pubkey,
                                             signatory,
-                                            stale_at: 0,
+                                            stale_at: 0.into(),
                                             certificate_options,
-                                            identities: HashMap::new(),
+                                            identities:HashMap::new().into(),
                                             piv_identities: self.piv_keys.iter().filter_map(|x| if x.1.in_use {Some((x.0.clone(), x.1.descriptor.clone()))} else {None}).collect(),
                                             notification_function: None,
                                             certificate_priority: self.certificate_priority,

--- a/rustica-agent-gui/src/main.rs
+++ b/rustica-agent-gui/src/main.rs
@@ -299,7 +299,7 @@ impl eframe::App for RusticaAgentGui {
                                         private_key.set_device_path(&self.fido_devices[*fido_device].path);
 
                                         let pubkey = private_key.pubkey.clone();
-                                        let signatory = Signatory::Direct(private_key);
+                                        let signatory = Signatory::Direct(private_key.into());
 
                                         let certificate_options = CertificateConfig::from(updatable_configuration.get_configuration().options.clone());
 

--- a/rustica-agent/src/ffi.rs
+++ b/rustica-agent/src/ffi.rs
@@ -16,10 +16,7 @@ use sshcerts::ssh::PrivateKey;
 use sshcerts::yubikey::piv::{AlgorithmId, PinPolicy, RetiredSlotId, SlotId, TouchPolicy, Yubikey};
 use tokio::{
     runtime::Runtime,
-    sync::{
-        mpsc::{channel, Sender},
-        Mutex,
-    },
+    sync::mpsc::{channel, Sender},
 };
 
 use std::fs::File;
@@ -295,7 +292,7 @@ pub unsafe extern "C" fn generate_and_enroll_fido(
 
     let runtime_handle = runtime.handle().to_owned();
 
-    let mut signatory = Signatory::Direct(new_fido_key.private_key.clone());
+    let mut signatory = Signatory::Direct(new_fido_key.private_key.clone().into());
     let u2f_attestation = U2FAttestation {
         auth_data: new_fido_key.attestation.auth_data,
         auth_data_sig: new_fido_key.attestation.auth_data_sig,
@@ -649,13 +646,13 @@ pub unsafe extern "C" fn start_direct_rustica_agent_with_piv_idents(
     certificate_options.authority = authority;
 
     let handler = Handler {
-        updatable_configuration: Mutex::new(updatable_configuration),
+        updatable_configuration: updatable_configuration.into(),
         cert: None.into(),
-        stale_at: Mutex::new(0),
+        stale_at: 0.into(),
         pubkey: private_key.pubkey.clone(),
         certificate_options,
-        signatory: Signatory::Direct(private_key),
-        identities: Mutex::new(HashMap::new()),
+        signatory: Signatory::Direct(private_key.into()),
+        identities: HashMap::new().into(),
         piv_identities,
         notification_function: Some(Box::new(notification_f)),
         certificate_priority,
@@ -753,16 +750,16 @@ pub unsafe extern "C" fn start_yubikey_rustica_agent(
     };
 
     let handler = Handler {
-        updatable_configuration: Mutex::new(updatable_configuration),
+        updatable_configuration: updatable_configuration.into(),
         cert: None.into(),
-        stale_at: Mutex::new(0),
+        stale_at: 0.into(),
         pubkey,
         certificate_options,
         signatory: Signatory::Yubikey(YubikeySigner {
-            yk: Mutex::new(Yubikey::open(yubikey_serial).unwrap()),
+            yk: Yubikey::open(yubikey_serial).unwrap().into(),
             slot: SlotId::try_from(slot).unwrap(),
         }),
-        identities: Mutex::new(HashMap::new()),
+        identities: HashMap::new().into(),
         piv_identities: HashMap::new(),
         notification_function: Some(Box::new(notification_f)),
         certificate_priority,

--- a/rustica-agent/src/ffi.rs
+++ b/rustica-agent/src/ffi.rs
@@ -16,7 +16,10 @@ use sshcerts::ssh::PrivateKey;
 use sshcerts::yubikey::piv::{AlgorithmId, PinPolicy, RetiredSlotId, SlotId, TouchPolicy, Yubikey};
 use tokio::{
     runtime::Runtime,
-    sync::mpsc::{channel, Sender},
+    sync::{
+        mpsc::{channel, Sender},
+        Mutex,
+    },
 };
 
 use std::fs::File;
@@ -425,7 +428,10 @@ pub unsafe extern "C" fn generate_and_enroll(
         Err(_) => return false,
     };
 
-    let mut signatory = Signatory::Yubikey(YubikeySigner { yk, slot });
+    let mut signatory = Signatory::Yubikey(YubikeySigner {
+        yk: yk.into(),
+        slot,
+    });
 
     let runtime = match Runtime::new() {
         Ok(rt) => rt,
@@ -643,13 +649,13 @@ pub unsafe extern "C" fn start_direct_rustica_agent_with_piv_idents(
     certificate_options.authority = authority;
 
     let handler = Handler {
-        updatable_configuration,
-        cert: None,
-        stale_at: 0,
+        updatable_configuration: Mutex::new(updatable_configuration),
+        cert: None.into(),
+        stale_at: Mutex::new(0),
         pubkey: private_key.pubkey.clone(),
         certificate_options,
         signatory: Signatory::Direct(private_key),
-        identities: HashMap::new(),
+        identities: Mutex::new(HashMap::new()),
         piv_identities,
         notification_function: Some(Box::new(notification_f)),
         certificate_priority,
@@ -747,16 +753,16 @@ pub unsafe extern "C" fn start_yubikey_rustica_agent(
     };
 
     let handler = Handler {
-        updatable_configuration,
-        cert: None,
-        stale_at: 0,
+        updatable_configuration: Mutex::new(updatable_configuration),
+        cert: None.into(),
+        stale_at: Mutex::new(0),
         pubkey,
         certificate_options,
         signatory: Signatory::Yubikey(YubikeySigner {
-            yk: Yubikey::open(yubikey_serial).unwrap(),
+            yk: Mutex::new(Yubikey::open(yubikey_serial).unwrap()),
             slot: SlotId::try_from(slot).unwrap(),
         }),
-        identities: HashMap::new(),
+        identities: Mutex::new(HashMap::new()),
         piv_identities: HashMap::new(),
         notification_function: Some(Box::new(notification_f)),
         certificate_priority,
@@ -946,7 +952,10 @@ pub unsafe extern "C" fn ffi_refresh_x509_certificate(
         return false;
     }
 
-    let mut signatory = Signatory::Yubikey(YubikeySigner { yk, slot });
+    let mut signatory = Signatory::Yubikey(YubikeySigner {
+        yk: yk.into(),
+        slot,
+    });
 
     let runtime = match Runtime::new() {
         Ok(rt) => rt,

--- a/rustica-agent/src/rustica/cert.rs
+++ b/rustica-agent/src/rustica/cert.rs
@@ -1,6 +1,6 @@
 use super::error::{RefreshError, ServerError};
 use super::{CertificateRequest, RusticaCert, Signatory};
-use crate::{CertificateConfig, RusticaServer, MtlsCredentials};
+use crate::{CertificateConfig, MtlsCredentials, RusticaServer};
 use sshcerts::Certificate;
 use tokio::runtime::Handle;
 
@@ -10,7 +10,7 @@ use std::time::SystemTime;
 impl RusticaServer {
     pub async fn refresh_certificate_async(
         &self,
-        signatory: &mut Signatory,
+        signatory: &Signatory,
         options: &CertificateConfig,
     ) -> Result<(RusticaCert, Option<MtlsCredentials>), RefreshError> {
         let (mut client, challenge) = super::complete_rustica_challenge(self, signatory).await?;
@@ -54,10 +54,13 @@ impl RusticaServer {
             None
         };
 
-        Ok((RusticaCert {
-            cert: response.certificate,
-            comment: "JITC".to_string(),
-        }, mtls_credentials))
+        Ok((
+            RusticaCert {
+                cert: response.certificate,
+                comment: "JITC".to_string(),
+            },
+            mtls_credentials,
+        ))
     }
 
     pub fn get_custom_certificate(
@@ -66,7 +69,6 @@ impl RusticaServer {
         options: &CertificateConfig,
         handle: &Handle,
     ) -> Result<(RusticaCert, Option<MtlsCredentials>), RefreshError> {
-        handle
-            .block_on(async { self.refresh_certificate_async(signatory, options).await })
+        handle.block_on(async { self.refresh_certificate_async(signatory, options).await })
     }
 }

--- a/rustica-agent/src/rustica/mod.rs
+++ b/rustica-agent/src/rustica/mod.rs
@@ -9,8 +9,8 @@ pub use error::RefreshError;
 
 pub use rustica_proto::rustica_client::RusticaClient;
 pub use rustica_proto::{
-    CertificateRequest, CertificateResponse, Challenge, ChallengeRequest, RegisterKeyRequest, AttestedX509CertificateRequest, AttestedX509CertificateResponse,
-    RegisterU2fKeyRequest,
+    AttestedX509CertificateRequest, AttestedX509CertificateResponse, CertificateRequest,
+    CertificateResponse, Challenge, ChallengeRequest, RegisterKeyRequest, RegisterU2fKeyRequest,
 };
 
 use sshcerts::ssh::Certificate as SSHCertificate;
@@ -28,7 +28,9 @@ pub struct RusticaCert {
     pub comment: String,
 }
 
-pub async fn get_rustica_client(server: &RusticaServer) -> Result<RusticaClient<tonic::transport::Channel>, RefreshError> {
+pub async fn get_rustica_client(
+    server: &RusticaServer,
+) -> Result<RusticaClient<tonic::transport::Channel>, RefreshError> {
     let client_identity = Identity::from_pem(&server.mtls_cert, &server.mtls_key);
 
     let channel = match Channel::from_shared(server.address.clone()) {
@@ -54,12 +56,13 @@ pub async fn get_rustica_client(server: &RusticaServer) -> Result<RusticaClient<
 
 pub async fn complete_rustica_challenge(
     server: &RusticaServer,
-    signatory: &mut Signatory,
+    signatory: &Signatory,
 ) -> Result<(RusticaClient<tonic::transport::Channel>, Challenge), RefreshError> {
     let ssh_pubkey = match signatory {
         Signatory::Yubikey(signer) => {
-            signer.yk.reconnect()?;
-            match signer.yk.ssh_cert_fetch_pubkey(&signer.slot) {
+            let mut yk = signer.yk.lock().await;
+            yk.reconnect()?;
+            match yk.ssh_cert_fetch_pubkey(&signer.slot) {
                 Ok(pkey) => pkey,
                 Err(_) => return Err(RefreshError::SigningError),
             }
@@ -112,6 +115,8 @@ pub async fn complete_rustica_challenge(
         Signatory::Yubikey(signer) => {
             let signature = signer
                 .yk
+                .lock()
+                .await
                 .ssh_cert_signer(&challenge_certificate.tbs_certificate(), &signer.slot)
                 .map_err(|_| RefreshError::SigningError)?;
             challenge_certificate

--- a/rustica-agent/src/rustica/x509.rs
+++ b/rustica-agent/src/rustica/x509.rs
@@ -3,40 +3,35 @@ use yubikey::piv::SlotId;
 
 use crate::{RusticaServer, Signatory};
 
-use super::{error::ServerError, get_rustica_client, RefreshError, AttestedX509CertificateRequest};
+use super::{error::ServerError, get_rustica_client, AttestedX509CertificateRequest, RefreshError};
 
 impl RusticaServer {
     pub async fn refresh_attested_x509_certificate_async(
         &self,
         signatory: &mut Signatory,
     ) -> Result<Vec<u8>, RefreshError> {
-        let yk_signatory = match signatory {
-            Signatory::Yubikey(yk) => yk,
+        let (mut yk, slot) = match signatory {
+            Signatory::Yubikey(yk) => (yk.yk.lock().await, yk.slot),
             _ => return Err(RefreshError::UnsupportedMode),
         };
 
         // The CN will be ignored by the backend
-        let csr = yk_signatory
-            .yk
-            .generate_csr(&yk_signatory.slot, "common_name")
-            .map_err(|_| {
-                RefreshError::ConfigurationError(format!(
-                    "Could not generate CSR for slot {}. Is it provisioned?",
-                    yk_signatory.slot
-                ))
-            })?;
+        let csr = yk.generate_csr(&slot, "common_name").map_err(|_| {
+            RefreshError::ConfigurationError(format!(
+                "Could not generate CSR for slot {}. Is it provisioned?",
+                slot
+            ))
+        })?;
 
-        yk_signatory.yk.reconnect().unwrap();
+        yk.reconnect().unwrap();
 
-        let attestation = yk_signatory.yk.fetch_attestation(&yk_signatory.slot).map_err(|e|
-            RefreshError::ConfigurationError(format!("Could not generate attestation for slot {}. Is it attestable (not imported)? Error {e}", yk_signatory.slot)))?;
+        let attestation = yk.fetch_attestation(&slot).map_err(|e|
+            RefreshError::ConfigurationError(format!("Could not generate attestation for slot {slot}. Is it attestable (not imported)? Error {e}")))?;
 
-        yk_signatory.yk.reconnect().unwrap();
+        yk.reconnect().unwrap();
 
-        let attestation_intermediate = yk_signatory
-            .yk
-            .fetch_certificate(&SlotId::Attestation)
-            .map_err(|_| {
+        let attestation_intermediate =
+            yk.fetch_certificate(&SlotId::Attestation).map_err(|_| {
                 RefreshError::ConfigurationError(format!(
                     "Could not fetch attestation intermediate. Have you manually removed it?"
                 ))
@@ -52,7 +47,10 @@ impl RusticaServer {
 
         let mut client = get_rustica_client(self).await?;
 
-        let response = client.attested_x509_certificate(request).await?.into_inner();
+        let response = client
+            .attested_x509_certificate(request)
+            .await?
+            .into_inner();
 
         match response.error_code {
             0 => Ok(response.certificate),
@@ -68,7 +66,9 @@ impl RusticaServer {
         signatory: &mut Signatory,
         handle: &Handle,
     ) -> Result<Vec<u8>, RefreshError> {
-        handle
-            .block_on(async { self.refresh_attested_x509_certificate_async(signatory).await })
+        handle.block_on(async {
+            self.refresh_attested_x509_certificate_async(signatory)
+                .await
+        })
     }
 }

--- a/rustica-agent/src/sshagent/agent.rs
+++ b/rustica-agent/src/sshagent/agent.rs
@@ -48,7 +48,7 @@ impl Agent {
                     v = listener.accept() => {
                         match v {
                             Ok(stream) => {
-                                debug!("Got connection from: {:?}. Spawing thread to handle.", stream.1);
+                                debug!("Got connection from: {:?}. Spawning thread to handle.", stream.1);
                                 let handler = handler.clone();
                                 tokio::spawn(async move {
                                     match Agent::handle_client(handler, stream.0).await {


### PR DESCRIPTION
Rustica Agent now spawns a thread to handle each request. Mutexes are used to ensure thread-safe concurrent accesses to some fields.

Tests done:
- `ssh -T git@github.com`
- 8 concurrent subprocesses calling `ssh -T git@github.com`
- 4 concurrent subprocesses calling `ssh -T git@github.com` and 3 concurrent subprocesses signing commit using PIV key.