### PR TITLE
Limit pubkey size in challenge request

### DIFF
--- a/rustica/src/server.rs
+++ b/rustica/src/server.rs
@@ -363,6 +363,22 @@ impl Rustica for RusticaServer {
             Err(_) => return Err(Status::permission_denied("")),
         };
 
+        // Limit the size of the public key to mitigate DoS
+        // ED25519 public key strings are 127 chars in length.
+        // But we will set a reasonably higher upper bound to accommodate other types of
+        // public keys
+        if request.pubkey.len() > 1024 {
+            rustica_warning!(
+                self,
+                format!(
+                    "The pubkey size is too large ({} chars) for a challenge request from [{}]",
+                    request.pubkey.len(),
+                    mtls_identities.join(","),
+                )
+            );
+            return Err(Status::permission_denied(""));
+        }
+
         let ssh_pubkey = match PublicKey::from_string(&request.pubkey) {
             Ok(sshpk) => sshpk,
             Err(_) => return Err(Status::permission_denied("")),


### PR DESCRIPTION
Limit the length of the public key string in the Challenge request to mitigate DoS risk. 

Testing done on local DB:
- Happy path of challenge request works. Was able to get challenge and register a FIDO key.
- Modified Rustica CLI to send a long public key in the Challenge request. Without the pubkey size limit, I was able to fetch a challenge. With the pubkey size limit, the assert works:
```
[2024-01-19T07:15:32Z WARN  rustica::logging::stdout] The pubkey size is too large (543 chars) for a challenge request from [obelisk]
```