### PR TITLE
Avoid wiping file before successful allowed_signers call

### DIFF
--- a/rustica-agent/src/ffi/allowed_signer.rs
+++ b/rustica-agent/src/ffi/allowed_signer.rs
@@ -55,14 +55,6 @@ pub unsafe extern "C" fn ffi_get_allowed_signers(
     };
     let runtime_handle = runtime.handle().to_owned();
 
-    let mut out_file = match File::create(out_path) {
-        Ok(f) => f,
-        Err(e) => {
-            error!("Could not create Allowed Signers file at {}: {}", out_path, e);
-            return GetAllowedSignersStatus::AllowedSignersFileError as i32;
-        }
-    };
-
     for server in &updatable_configuration.get_configuration().servers {
         let allowed_signers = match server.get_allowed_signers(&runtime_handle) {
             Ok(data) => {
@@ -76,6 +68,14 @@ pub unsafe extern "C" fn ffi_get_allowed_signers(
                 error!("Allowed signers could not be fetched. Server said: {}", e);
                 continue;
             },
+        };
+
+        let mut out_file = match File::create(out_path) {
+            Ok(f) => f,
+            Err(e) => {
+                error!("Could not create Allowed Signers file at {}: {}", out_path, e);
+                return GetAllowedSignersStatus::AllowedSignersFileError as i32;
+            }
         };
 
         match out_file.write_all(allowed_signers.as_bytes()) {


### PR DESCRIPTION
Only wipe the file after we know we have data to write. This avoid wiping the file when our remote call fails.