### PR TITLE
Fix PIN issue with PIV signing

### DIFF
--- a/rustica-agent/src/lib.rs
+++ b/rustica-agent/src/lib.rs
@@ -78,6 +78,10 @@ impl YubikeySigner {
         let pin = serial
             .and_then(yubikey_pin_from_env)
             .or_else(|| env::var("YK_PIN").ok());
+        println!(
+            "Yubikey signer for slot {slot:?} (serial {serial:?}): pin_required={pin_required}, pin_resolved={}",
+            pin.is_some()
+        );
         Self {
             yk: yk.into(),
             slot,
@@ -477,19 +481,24 @@ impl SshAgentHandler for Handler {
                 println!("Skipping notification for no-touch key");
             }
 
-            if descriptor.pin_required {
-                match &descriptor.pin {
-                    Some(pin) => verify_yk_pin(&mut yk, descriptor.serial, pin)?,
-                    None => {
-                        println!("Key requires a PIN but none was provided (set YK_PIN)");
-                        return Err(AgentError::from("Yubikey PIN required but not provided"));
-                    }
+            match &descriptor.pin {
+                Some(pin) => verify_yk_pin(&mut yk, descriptor.serial, pin)?,
+                None if descriptor.pin_required => {
+                    println!("Key requires a PIN but none was provided (set YK_PIN)");
+                    return Err(AgentError::from("Yubikey PIN required but not provided"));
                 }
+                None => {}
             }
 
             let signature = yk.ssh_cert_signer(&data, &descriptor.slot).map_err(|e| {
                 println!("Signing Error: {e}");
-                AgentError::from("Yubikey signing error")
+                if descriptor.pin.is_none() {
+                    AgentError::from(
+                        "Yubikey signing error (slot may require a PIN that wasn't provided)",
+                    )
+                } else {
+                    AgentError::from("Yubikey signing error")
+                }
             })?;
 
             return Ok(Response::SignResponse { signature });
@@ -557,19 +566,24 @@ impl SshAgentHandler for Handler {
                 }
             }
 
-            if signer.pin_required {
-                match &signer.pin {
-                    Some(pin) => verify_yk_pin(&mut yk, signer.serial.unwrap_or_default(), pin)?,
-                    None => {
-                        println!("Key requires a PIN but none was provided (set YK_PIN)");
-                        return Err(AgentError::from("Yubikey PIN required but not provided"));
-                    }
+            match &signer.pin {
+                Some(pin) => verify_yk_pin(&mut yk, signer.serial.unwrap_or_default(), pin)?,
+                None if signer.pin_required => {
+                    println!("Key requires a PIN but none was provided (set YK_PIN)");
+                    return Err(AgentError::from("Yubikey PIN required but not provided"));
                 }
+                None => {}
             }
 
             let signature = yk.ssh_cert_signer(&data, &signer.slot).map_err(|e| {
                 println!("Signing Error: {e}");
-                AgentError::from("Yubikey signing error")
+                if signer.pin.is_none() {
+                    AgentError::from(
+                        "Yubikey signing error (slot may require a PIN that wasn't provided)",
+                    )
+                } else {
+                    AgentError::from("Yubikey signing error")
+                }
             })?;
 
             return Ok(Response::SignResponse { signature });

--- a/rustica-agent/src/sshagent/agent.rs
+++ b/rustica-agent/src/sshagent/agent.rs
@@ -5,7 +5,7 @@ use tokio::net::UnixStream;
 use tokio::select;
 use tokio::sync::mpsc::Receiver;
 
-use super::protocol::Request;
+use super::protocol::{Request, Response};
 
 use super::handler::SshAgentHandler;
 
@@ -20,7 +20,13 @@ impl Agent {
         loop {
             let req = Request::read(&mut stream).await?;
             trace!("request: {:?}", req);
-            let response = handler.handle_request(req).await?;
+            let response = match handler.handle_request(req).await {
+                Ok(response) => response,
+                Err(e) => {
+                    debug!("sign/handler request failed: {:?}", e);
+                    Response::Failure
+                }
+            };
             trace!("handler: {:?}", response);
             response.write(&mut stream).await?;
         }


### PR DESCRIPTION
1. PIN is not verified before signing: The `pin_required` check is not reliable, causing signing to incorrectly skip PIN verification.
2. One failed sign killed the whole connection: the agent drops the socket on any handler error instead of replying SSH_AGENT_FAILURE, so the next key offered fails too as collateral damage.