### PR TITLE
Add reconnect recovery for PIV registration too

### DIFF
--- a/.github/workflows/config_check.yml
+++ b/.github/workflows/config_check.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/checkout@v2
     - name: Install libpcsc
       run: sudo apt install -y libpcsclite-dev libusb-1.0-0-dev libudev-dev

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/checkout@v2
     - name: Install libpcsc
       run: sudo apt install -y libpcsclite-dev libusb-1.0-0-dev libudev-dev

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: actions/checkout@v6
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --package=rustica --features=all
@@ -26,6 +28,8 @@ jobs:
     steps:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --package=rustica --features=splunk
@@ -36,6 +40,8 @@ jobs:
     steps:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --package=rustica --features=influx
@@ -46,6 +52,8 @@ jobs:
     steps:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --package=rustica --features=local-db
@@ -56,6 +64,8 @@ jobs:
     steps:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --package=rustica --features=amazon-kms
@@ -66,6 +76,8 @@ jobs:
     steps:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --package=rustica --features="splunk,influx,local-db,amazon-kms"

--- a/rustica-agent-gui/src/main.rs
+++ b/rustica-agent-gui/src/main.rs
@@ -8,7 +8,7 @@ use egui::ComboBox;
 
 use home::home_dir;
 use rustica_agent::Yubikey;
-use rustica_agent::{get_all_piv_keys, YubikeyPIVKeyDescriptor};
+use rustica_agent::{get_all_piv_keys, is_yk_reset_error, YubikeyPIVKeyDescriptor};
 use tokio::{runtime::Runtime, sync::mpsc::Sender};
 
 #[derive(Debug)]
@@ -259,9 +259,20 @@ impl eframe::App for RusticaAgentGui {
                                         if ui.button("Unlock").clicked() {
                                             let pin_bytes = self.unlock_pin.as_bytes().to_owned();
                                             let yk = Yubikey::open(ui_key_handle.descriptor.serial);
+                                            let management_key = hex::decode("010203040506070801020304050607080102030405060708").unwrap();
                                             if let Ok(mut yk) = yk {
-                                                match yk.unlock(&pin_bytes, &hex::decode("010203040506070801020304050607080102030405060708").unwrap()) {
+                                                let unlock_result = match yk.unlock(&pin_bytes, &management_key) {
+                                                    Ok(_) => Ok(()),
+                                                    Err(e) if is_yk_reset_error(&e) => {
+                                                        yk.reconnect().and_then(|_| yk.unlock(&pin_bytes, &management_key))
+                                                    }
+                                                    Err(e) => Err(e),
+                                                };
+                                                match unlock_result {
                                                     Ok(_) => ui_key_handle.descriptor.pin = Some(self.unlock_pin.clone()),
+                                                    Err(e) if is_yk_reset_error(&e) => {
+                                                        self.status = "Unlock failed: the Yubikey was reset (not a PIN issue) — reconnect the key and try again".to_owned();
+                                                    }
                                                     Err(_) => {
                                                         match yk.yk.get_pin_retries() {
                                                             Ok(retries) => self.status = format!("Unlock failed, {retries} tries remaining"),

--- a/rustica-agent/src/ffi/enrollment.rs
+++ b/rustica-agent/src/ffi/enrollment.rs
@@ -3,7 +3,7 @@ use std::os::unix::fs::PermissionsExt;
 
 use crate::config::UpdatableConfiguration;
 use crate::rustica::key::U2FAttestation;
-use crate::{PIVAttestation, Signatory, YubikeySigner};
+use crate::{is_yk_reset_error, PIVAttestation, Signatory, YubikeySigner};
 
 use sshcerts::error::Error as SSHCertsError;
 use sshcerts::fido::generate::generate_new_ssh_key;
@@ -61,17 +61,36 @@ unsafe fn parse_piv_args(
 
 /// Shared by `generate_and_enroll` and `enroll_existing_piv`: unlock the
 /// YubiKey, mapping an unlock failure to a status code that either reports
-/// the PIV PIN attempts remaining (negative) or that the key is blocked.
+/// the PIV PIN attempts remaining (negative), that the key is blocked, or
+/// (if the failure looks like a PC/SC card reset rather than a wrong PIN)
+/// a communication error, after one reconnect-and-retry attempt.
 fn unlock_or_pin_status(yk: &mut Yubikey, pin: &str, management_key: &[u8]) -> Result<(), i64> {
-    if let Err(e) = yk.unlock(pin.as_bytes(), management_key) {
-        error!("Could not unlock key: {e}");
-        return Err(match yk.yk.get_pin_retries() {
-            Ok(0) => GenerateAndEnrollStatus::KeyBlocked as i64,
-            Ok(n) => -(n as i64),
-            Err(_) => GenerateAndEnrollStatus::UnknownAttemptsRemaining as i64,
-        });
+    let e = match yk.unlock(pin.as_bytes(), management_key) {
+        Ok(_) => return Ok(()),
+        Err(e) => e,
+    };
+    error!("Could not unlock key: {e}");
+
+    if is_yk_reset_error(&e) {
+        println!("Unlock hit a reset-like error, reconnecting and retrying once");
+        let retry_result = yk.reconnect().and_then(|_| yk.unlock(pin.as_bytes(), management_key));
+        match retry_result {
+            Ok(_) => return Ok(()),
+            Err(e) if !is_yk_reset_error(&e) => {
+                error!("Could not unlock key on retry: {e}");
+            }
+            Err(e) => {
+                error!("Unlock still failing after reconnect: {e}");
+                return Err(GenerateAndEnrollStatus::YubikeyCommunicationError as i64);
+            }
+        }
     }
-    Ok(())
+
+    Err(match yk.yk.get_pin_retries() {
+        Ok(0) => GenerateAndEnrollStatus::KeyBlocked as i64,
+        Ok(n) => -(n as i64),
+        Err(_) => GenerateAndEnrollStatus::UnknownAttemptsRemaining as i64,
+    })
 }
 
 #[no_mangle]

--- a/rustica-agent/src/ffi/enrollment.rs
+++ b/rustica-agent/src/ffi/enrollment.rs
@@ -73,7 +73,9 @@ fn unlock_or_pin_status(yk: &mut Yubikey, pin: &str, management_key: &[u8]) -> R
 
     if is_yk_reset_error(&e) {
         println!("Unlock hit a reset-like error, reconnecting and retrying once");
-        let retry_result = yk.reconnect().and_then(|_| yk.unlock(pin.as_bytes(), management_key));
+        let retry_result = yk
+            .reconnect()
+            .and_then(|_| yk.unlock(pin.as_bytes(), management_key));
         match retry_result {
             Ok(_) => return Ok(()),
             Err(e) if !is_yk_reset_error(&e) => {

--- a/rustica-agent/src/ffi/enrollment.rs
+++ b/rustica-agent/src/ffi/enrollment.rs
@@ -3,7 +3,7 @@ use std::os::unix::fs::PermissionsExt;
 
 use crate::config::UpdatableConfiguration;
 use crate::rustica::key::U2FAttestation;
-use crate::{is_yk_reset_error, PIVAttestation, Signatory, YubikeySigner};
+use crate::{is_yk_reset_error, yk_serial_lock, PIVAttestation, Signatory, YubikeySigner};
 
 use sshcerts::error::Error as SSHCertsError;
 use sshcerts::fido::generate::generate_new_ssh_key;
@@ -65,6 +65,9 @@ unsafe fn parse_piv_args(
 /// (if the failure looks like a PC/SC card reset rather than a wrong PIN)
 /// a communication error, after one reconnect-and-retry attempt.
 fn unlock_or_pin_status(yk: &mut Yubikey, pin: &str, management_key: &[u8]) -> Result<(), i64> {
+    let serial_lock = yk_serial_lock(yk.yk.serial().into());
+    let _guard = serial_lock.blocking_lock();
+
     let e = match yk.unlock(pin.as_bytes(), management_key) {
         Ok(_) => return Ok(()),
         Err(e) => e,
@@ -73,18 +76,17 @@ fn unlock_or_pin_status(yk: &mut Yubikey, pin: &str, management_key: &[u8]) -> R
 
     if is_yk_reset_error(&e) {
         println!("Unlock hit a reset-like error, reconnecting and retrying once");
-        let retry_result = yk
-            .reconnect()
-            .and_then(|_| yk.unlock(pin.as_bytes(), management_key));
-        match retry_result {
+        if let Err(e) = yk.reconnect() {
+            error!("Reconnect after card reset failed: {e}");
+            return Err(GenerateAndEnrollStatus::YubikeyCommunicationError as i64);
+        }
+        match yk.unlock(pin.as_bytes(), management_key) {
             Ok(_) => return Ok(()),
-            Err(e) if !is_yk_reset_error(&e) => {
-                error!("Could not unlock key on retry: {e}");
-            }
-            Err(e) => {
+            Err(e) if is_yk_reset_error(&e) => {
                 error!("Unlock still failing after reconnect: {e}");
                 return Err(GenerateAndEnrollStatus::YubikeyCommunicationError as i64);
             }
+            Err(e) => error!("Could not unlock key on retry: {e}"),
         }
     }
 

--- a/rustica-agent/src/ffi/yubikey_utils.rs
+++ b/rustica-agent/src/ffi/yubikey_utils.rs
@@ -61,7 +61,8 @@ pub unsafe extern "C" fn ffi_device_pin_retries(device: *const c_char) -> i32 {
 /// determined. `-10` if the unlock failed because the PC/SC card was reset
 /// (not because of a wrong PIN) and a reconnect-and-retry still failed; the
 /// PIN attempt counter is unaffected in this case. Any other positive value
-/// is the number of PIN attempts remaining after a genuine PIN failure.
+/// is the number of PIN attempts remaining at the time of the failure (which
+/// may be unchanged if the failure was not a wrong-PIN case).
 #[no_mangle]
 pub unsafe extern "C" fn unlock_yubikey(
     yubikey_serial: *const c_int,

--- a/rustica-agent/src/ffi/yubikey_utils.rs
+++ b/rustica-agent/src/ffi/yubikey_utils.rs
@@ -4,8 +4,8 @@ use sshcerts::yubikey::piv::{RetiredSlotId, SlotId, Yubikey};
 use tokio::runtime::Runtime;
 
 use crate::{
-    config::UpdatableConfiguration, is_yk_reset_error, list_yubikey_serials, Signatory,
-    YubikeySigner,
+    config::UpdatableConfiguration, is_yk_reset_error, list_yubikey_serials, yk_serial_lock,
+    Signatory, YubikeySigner,
 };
 
 /// Check if the device path will require a pin to generate a new key
@@ -75,6 +75,8 @@ pub unsafe extern "C" fn unlock_yubikey(
             return -1;
         }
     };
+    let serial_lock = yk_serial_lock(yk.yk.serial().into());
+    let _guard = serial_lock.blocking_lock();
 
     let pin = if !pin.is_null() {
         let pin = CStr::from_ptr(pin);
@@ -113,10 +115,11 @@ pub unsafe extern "C" fn unlock_yubikey(
 
     if is_yk_reset_error(&e) {
         println!("Unlock hit a reset-like error, reconnecting and retrying once");
-        let retry_result = yk
-            .reconnect()
-            .and_then(|_| yk.unlock(pin.as_bytes(), &management_key));
-        match retry_result {
+        if let Err(e) = yk.reconnect() {
+            println!("Reconnect after card reset failed: {e}");
+            return -10;
+        }
+        match yk.unlock(pin.as_bytes(), &management_key) {
             Ok(_) => return 0,
             Err(e) if is_yk_reset_error(&e) => {
                 println!("Unlock still failing after reconnect: {e}");

--- a/rustica-agent/src/ffi/yubikey_utils.rs
+++ b/rustica-agent/src/ffi/yubikey_utils.rs
@@ -3,7 +3,10 @@ use std::ffi::{c_char, c_int, c_long, CStr, CString};
 use sshcerts::yubikey::piv::{RetiredSlotId, SlotId, Yubikey};
 use tokio::runtime::Runtime;
 
-use crate::{config::UpdatableConfiguration, list_yubikey_serials, Signatory, YubikeySigner};
+use crate::{
+    config::UpdatableConfiguration, is_yk_reset_error, list_yubikey_serials, Signatory,
+    YubikeySigner,
+};
 
 /// Check if the device path will require a pin to generate a new key
 /// # Safety
@@ -52,6 +55,13 @@ pub unsafe extern "C" fn ffi_device_pin_retries(device: *const c_char) -> i32 {
     }
 }
 
+/// Unlock a Yubikey with the given PIN and management key.
+/// # Return
+/// `0` on success. `-9` if the PIN attempts remaining could not be
+/// determined. `-10` if the unlock failed because the PC/SC card was reset
+/// (not because of a wrong PIN) and a reconnect-and-retry still failed; the
+/// PIN attempt counter is unaffected in this case. Any other positive value
+/// is the number of PIN attempts remaining after a genuine PIN failure.
 #[no_mangle]
 pub unsafe extern "C" fn unlock_yubikey(
     yubikey_serial: *const c_int,
@@ -95,13 +105,28 @@ pub unsafe extern "C" fn unlock_yubikey(
         return -4;
     };
 
-    match yk.unlock(pin.as_bytes(), &management_key) {
-        Ok(_) => 0,
-        Err(e) => {
-            println!("Error unlocking key: {e}");
-            return yk.yk.get_pin_retries().map(|x| x as i32).unwrap_or(-9);
+    let e = match yk.unlock(pin.as_bytes(), &management_key) {
+        Ok(_) => return 0,
+        Err(e) => e,
+    };
+    println!("Error unlocking key: {e}");
+
+    if is_yk_reset_error(&e) {
+        println!("Unlock hit a reset-like error, reconnecting and retrying once");
+        let retry_result = yk
+            .reconnect()
+            .and_then(|_| yk.unlock(pin.as_bytes(), &management_key));
+        match retry_result {
+            Ok(_) => return 0,
+            Err(e) if is_yk_reset_error(&e) => {
+                println!("Unlock still failing after reconnect: {e}");
+                return -10;
+            }
+            Err(e) => println!("Error unlocking key on retry: {e}"),
         }
     }
+
+    yk.yk.get_pin_retries().map(|x| x as i32).unwrap_or(-9)
 }
 
 /// Fetch the list of serial numbers for the connected Yubikeys

--- a/rustica-agent/src/lib.rs
+++ b/rustica-agent/src/lib.rs
@@ -616,7 +616,7 @@ pub(crate) fn yk_serial_lock(serial: u32) -> Arc<Mutex<()>> {
 /// True when a signing error indicates the PC/SC card was reset out from
 /// under us (e.g. by another process like `ykman`). `Unsupported` counts
 /// because sshcerts collapses resets hit during its key-type fetch into it.
-pub(crate) fn is_yk_reset_error(e: &YkPivError) -> bool {
+pub fn is_yk_reset_error(e: &YkPivError) -> bool {
     match e {
         YkPivError::InternalYubiKeyError(msg) => msg.contains("has been reset"),
         YkPivError::Unsupported => true,

--- a/rustica-agent/src/lib.rs
+++ b/rustica-agent/src/lib.rs
@@ -613,7 +613,7 @@ pub(crate) fn yk_serial_lock(serial: u32) -> Arc<Mutex<()>> {
     map.entry(serial).or_default().clone()
 }
 
-/// True when a signing error indicates the PC/SC card was reset out from
+/// True when a PIV operation error indicates the PC/SC card was reset out from
 /// under us (e.g. by another process like `ykman`). `Unsupported` counts
 /// because sshcerts collapses resets hit during its key-type fetch into it.
 pub fn is_yk_reset_error(e: &YkPivError) -> bool {


### PR DESCRIPTION
For the PIV signing calls, we detect smartcard errors, we would try to recover with `yk.reconnect()`. Porting the same recovery to registration.